### PR TITLE
server commit interfaces

### DIFF
--- a/src/main/kotlin/io/titandata/remote/RemoteClient.kt
+++ b/src/main/kotlin/io/titandata/remote/RemoteClient.kt
@@ -6,8 +6,8 @@ package io.titandata.remote
 import java.net.URI
 
 /**
- * The remote client interface defines functionality that runs in the context of the titan. It is responsible for
- * parsing the URI format of remotes, validating remote properties, and createing remote parameters. It can consume
+ * The remote client interface defines functionality that runs in the context of the titan CLI. It is responsible for
+ * parsing the URI format of remotes, validating remote properties, and creating remote parameters. It can consume
  * data within the user's context, such as AWS credentials or local SSH keys, that will be passed to the server
  * side implementation.
  */

--- a/src/main/kotlin/io/titandata/remote/RemoteServer.kt
+++ b/src/main/kotlin/io/titandata/remote/RemoteServer.kt
@@ -7,6 +7,12 @@ package io.titandata.remote
 interface RemoteServer {
 
     /**
+     * Returns the canonical name of this provider, such as "ssh" or "s3". This must be globally unique, and must
+     * match the name used in the corresponding client.
+     */
+    fun getProvider(): String
+
+    /**
      * Fetches a set of commits from the remote server. Commits are simply a tuple of (commitId, properties), with
      * some properties having semantic significance (namely timestamp and tags). The remote provider should always
      * return commits in reverse timestamp order, optionally filtered by the given tags. There are utility methods

--- a/src/main/kotlin/io/titandata/remote/RemoteServer.kt
+++ b/src/main/kotlin/io/titandata/remote/RemoteServer.kt
@@ -1,0 +1,25 @@
+package io.titandata.remote
+
+/**
+ * The remote client interface defines functionality that runs in the context of the titan server. It is responsible for
+ * fetching remote commits and running push / pull operations.
+ */
+interface RemoteServer {
+
+    /**
+     * Fetches a set of commits from the remote server. Commits are simply a tuple of (commitId, properties), with
+     * some properties having semantic significance (namely timestamp and tags). The remote provider should always
+     * return commits in reverse timestamp order, optionally filtered by the given tags. There are utility methods
+     * in RemoteServerUtil if remotes don't provide this functionality server-side. Tags are specified as a list of
+     * pairs, where the first element is always the key and the second is optionally the value.
+     *
+     * There is not yet support for pagination, though that will be added in the future to avoid having to fetch
+     * the entire commit history every time.
+     */
+    fun listCommits(remote: Map<String, Any>, parameters: Map<String, Any>, tags: List<Pair<String, String?>>): List<Pair<String, Map<String, Any>>>
+
+    /**
+     * Fetches a single commit from the given remote. Returns null if no such commit exists.
+     */
+    fun getCommit(remote: Map<String, Any>, parameters: Map<String, Any>, commitId: String): Map<String, Any>?
+}

--- a/src/main/kotlin/io/titandata/remote/RemoteServerUtil.kt
+++ b/src/main/kotlin/io/titandata/remote/RemoteServerUtil.kt
@@ -1,0 +1,46 @@
+package io.titandata.remote
+
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+
+class RemoteServerUtil {
+
+    /**
+     * Sorts a list of commits in reverse descending order, based on timestamp.
+     */
+    fun sortDescending(commits: List<Pair<String, Map<String, Any>>>): List<Pair<String, Map<String, Any>>> {
+        return commits.sortedByDescending { OffsetDateTime.parse(it.second.get("timestamp")?.toString()
+                ?: DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochSecond(0)),
+                DateTimeFormatter.ISO_DATE_TIME) }
+    }
+
+    /**
+     * Match a commit against a set of tags. Returns true if the commit matches the given tags, false otherwise.
+     */
+    fun matchTags(commit: Map<String, Any>, tags: List<Pair<String, String?>>): Boolean {
+        if (tags.size == 0) {
+            return true
+        }
+
+        val metadata = commit.get("tags")
+        if (metadata == null || metadata !is Map<*, *>) {
+            return false
+        }
+        @Suppress("UNCHECKED_CAST")
+        metadata as Map<String, String>
+
+        for (tag in tags) {
+            val key = tag.first
+            if (!metadata.containsKey(key)) {
+                return false
+            }
+
+            if (tag.second != null && metadata.get(key) != tag.second) {
+                return false
+            }
+        }
+
+        return true
+    }
+}

--- a/src/test/kotlin/io/titandata/remote/RemoteServerUtilTest.kt
+++ b/src/test/kotlin/io/titandata/remote/RemoteServerUtilTest.kt
@@ -1,0 +1,76 @@
+package io.titandata.remote
+
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.StringSpec
+
+class RemoteServerUtilTest : StringSpec() {
+
+    private val util = RemoteServerUtil()
+
+    private fun makeCommit(vararg tags: Pair<String, String>): Map<String, Any> {
+        if (tags.size == 0) {
+            return emptyMap()
+        } else {
+            return mapOf("tags" to mapOf(*tags))
+        }
+    }
+
+    init {
+        "empty tags allows any commit" {
+            util.matchTags(makeCommit(), emptyList()) shouldBe true
+            util.matchTags(makeCommit("a" to "b"), emptyList()) shouldBe true
+            util.matchTags(makeCommit("c" to "d"), emptyList()) shouldBe true
+        }
+
+        "exact match works correctly" {
+            val tags = listOf("a" to "b")
+            util.matchTags(makeCommit(), tags) shouldBe false
+            util.matchTags(makeCommit("a" to "b"), tags) shouldBe true
+            util.matchTags(makeCommit("c" to "d"), tags) shouldBe false
+        }
+
+        "existence match works correctly" {
+            val tags = listOf("a" to null)
+            util.matchTags(makeCommit(), tags) shouldBe false
+            util.matchTags(makeCommit("a" to "b"), tags) shouldBe true
+            util.matchTags(makeCommit("c" to "d"), tags) shouldBe false
+        }
+
+        "multiple checks works correctly" {
+            val tags = listOf("a" to null, "c" to "d")
+            util.matchTags(makeCommit("a" to "b"), tags) shouldBe false
+            util.matchTags(makeCommit("c" to "d"), tags) shouldBe false
+            util.matchTags(makeCommit("a" to "b", "c" to "d"), tags) shouldBe true
+        }
+
+        "sort descending works" {
+            val commits = listOf(
+                    "four" to mapOf("timestamp" to "2019-09-21T13:45:30Z"),
+                    "one" to mapOf("timestamp" to "2019-09-20T13:45:36Z"),
+                    "three" to mapOf("timestamp" to "2019-09-20T13:45:38Z"),
+                    "two" to mapOf("timestamp" to "2019-09-20T13:45:37Z")
+            )
+            val sorted = util.sortDescending(commits)
+            sorted.size shouldBe 4
+            sorted[0].first shouldBe "four"
+            sorted[1].first shouldBe "three"
+            sorted[2].first shouldBe "two"
+            sorted[3].first shouldBe "one"
+        }
+
+        "sort descending places commits without timestamps last" {
+            val commits = listOf(
+                    "four" to mapOf(),
+                    "one" to mapOf("timestamp" to "2019-09-20T13:45:36Z"),
+                    "three" to mapOf("timestamp" to "2019-09-20T13:45:38Z"),
+                    "two" to mapOf("timestamp" to "2019-09-20T13:45:37Z")
+            )
+            val sorted = util.sortDescending(commits)
+            sorted.size shouldBe 4
+            sorted[0].first shouldBe "three"
+            sorted[1].first shouldBe "two"
+            sorted[2].first shouldBe "one"
+            sorted[3].first shouldBe "four"
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes

This adds the server-side service, with methods to manage remote commits.

## Testing

`gradle build`. Also built and tested the nop remote provider, standalone and within `titan-server`.
