### PR TITLE
full support for operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build files
 /.gradle
 /build
+/out
 
 # IDE files
 /.idea

--- a/src/main/kotlin/io/titandata/remote/RemoteClient.kt
+++ b/src/main/kotlin/io/titandata/remote/RemoteClient.kt
@@ -1,6 +1,7 @@
 /*
  * Copyright The Titan Project Contributors.
  */
+
 package io.titandata.remote
 
 import java.net.URI

--- a/src/main/kotlin/io/titandata/remote/RemoteClientUtil.kt
+++ b/src/main/kotlin/io/titandata/remote/RemoteClientUtil.kt
@@ -1,6 +1,7 @@
 /*
  * Copyright The Titan Project Contributors.
  */
+
 package io.titandata.remote
 
 import java.net.URI

--- a/src/main/kotlin/io/titandata/remote/RemoteServer.kt
+++ b/src/main/kotlin/io/titandata/remote/RemoteServer.kt
@@ -117,4 +117,11 @@ interface RemoteServer {
      * once per operation, and can be used to store any temporary state, even across operations.
      */
     fun syncVolume(operation: RemoteOperation, volumeName: String, volumeDescription: String, volumePath: String, scratchPath: String)
+
+    /**
+     * Push metadata for the commit to the remote. This can be done either when creating a new commit, or when
+     * doing a metadata-only update (e.g. pushing new tags). The 'isUpdate' flag indicates whether we are updating
+     * existing metadata or creating new metadata.
+     */
+    fun pushMetadata(operation: RemoteOperation, commit: Map<String, Any>, isUpdate: Boolean)
 }

--- a/src/main/kotlin/io/titandata/remote/RemoteServer.kt
+++ b/src/main/kotlin/io/titandata/remote/RemoteServer.kt
@@ -42,6 +42,8 @@ enum class RemoteOperationType {
  *
  *      commitId            Commit being pushed or pulled
  *
+ *      commit              Commit metadata, if this is a push operation.
+ *
  *      type                Operation type (push or pull)
  *
  *      userData            Optional data, set by startOperation(), that can be used during the course of the operation.
@@ -52,6 +54,7 @@ data class RemoteOperation(
     val parameters: Map<String, Any>,
     val operationId: String,
     val commitId: String,
+    val commit: Map<String, Any>?,
     val type: RemoteOperationType,
     var data: Any?
 )

--- a/src/main/kotlin/io/titandata/remote/RemoteServer.kt
+++ b/src/main/kotlin/io/titandata/remote/RemoteServer.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
 package io.titandata.remote
 
 /**

--- a/src/main/kotlin/io/titandata/remote/RemoteServerUtil.kt
+++ b/src/main/kotlin/io/titandata/remote/RemoteServerUtil.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
 package io.titandata.remote
 
 import java.time.Instant

--- a/src/main/kotlin/io/titandata/remote/archive/ArchiveRemote.kt
+++ b/src/main/kotlin/io/titandata/remote/archive/ArchiveRemote.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
+package io.titandata.remote.archive
+
+import io.titandata.remote.RemoteOperation
+import io.titandata.remote.RemoteOperationType
+import io.titandata.remote.RemoteProgress
+import io.titandata.remote.RemoteServer
+import io.titandata.shell.CommandExecutor
+import java.io.File
+
+/**
+ * This is a helper class for remote providers that operate by sending full archives of volumes (e.g. S3 and S3web).
+ * It handles the basics of creating or extracting the archives, and invokes a simpler upload / download interface.
+ */
+abstract class ArchiveRemote : RemoteServer {
+
+    internal val executor = CommandExecutor()
+
+    abstract fun pushArchive(operation: RemoteOperation, volume: String, archive: File)
+    abstract fun pullArchive(operation: RemoteOperation, volume: String, archive: File)
+
+    override fun syncVolume(
+        operation: RemoteOperation,
+        volumeName: String,
+        volumeDescription: String,
+        volumePath: String,
+        scratchPath: String
+    ) {
+        if (operation.type == RemoteOperationType.PUSH) {
+            operation.updateProgress(RemoteProgress.START, "Creating archive for $volumeDescription", null)
+            val archive = "$scratchPath/$volumeName.tar.gz"
+            val args = arrayOf("tar", "czf", archive, ".")
+            val process = ProcessBuilder()
+                    .directory(File(volumePath))
+                    .command(*args)
+                    .start()
+            executor.exec(process, args.joinToString())
+            operation.updateProgress(RemoteProgress.END, null, null)
+
+            operation.updateProgress(RemoteProgress.START, "Pushing archive for $volumeDescription", null)
+            pushArchive(operation, volumeName, File(archive))
+            File(archive).delete()
+            operation.updateProgress(RemoteProgress.END, null, null)
+        } else {
+            operation.updateProgress(RemoteProgress.START, "Pulling archive for $volumeDescription", null)
+            val archive = "$scratchPath/$volumeName.tar.gz"
+            pullArchive(operation, volumeName, File(archive))
+            operation.updateProgress(RemoteProgress.END, null, null)
+
+            operation.updateProgress(RemoteProgress.START,
+                    "Extracting archive for $volumeDescription", null)
+            val args = arrayOf("tar", "xzf", archive)
+            val process = ProcessBuilder()
+                    .directory(File(volumePath))
+                    .command(*args)
+                    .start()
+            executor.exec(process, args.joinToString())
+            operation.updateProgress(RemoteProgress.END, null, null)
+        }
+    }
+}

--- a/src/main/kotlin/io/titandata/remote/rsync/RsyncRemote.kt
+++ b/src/main/kotlin/io/titandata/remote/rsync/RsyncRemote.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
+package io.titandata.remote.rsync
+
+import io.titandata.remote.RemoteOperation
+import io.titandata.remote.RemoteOperationType
+import io.titandata.remote.RemoteProgress
+import io.titandata.remote.RemoteServer
+import io.titandata.shell.CommandExecutor
+
+/**
+ * This is a helper class for remote providers that operate by executing rsync (e.g. SSH). It handles the common
+ * elements of syncing volumes.
+ */
+abstract class RsyncRemote : RemoteServer {
+
+    internal val executor = CommandExecutor()
+
+    abstract fun getRemotePath(operation: RemoteOperation, volume: String): String
+    abstract fun getRsync(operation: RemoteOperation, src: String, dst: String, executor: CommandExecutor): RsyncExecutor
+
+    override fun syncVolume(
+        operation: RemoteOperation,
+        volumeName: String,
+        volumeDescription: String,
+        volumePath: String,
+        scratchPath: String
+    ) {
+        val remotePath = getRemotePath(operation, volumeName)
+        val (src, dst) = if (operation.type == RemoteOperationType.PUSH) {
+            volumePath to remotePath
+        } else {
+            remotePath to volumePath
+        }
+
+        operation.updateProgress(RemoteProgress.START, "Syncing $volumeDescription", 0)
+        val rsync = getRsync(operation, src, dst, executor)
+        rsync.run()
+    }
+}

--- a/src/test/kotlin/io/titandata/remote/RemoteClientUtilTest.kt
+++ b/src/test/kotlin/io/titandata/remote/RemoteClientUtilTest.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
 package io.titandata.remote
 
 import io.kotlintest.shouldBe

--- a/src/test/kotlin/io/titandata/remote/RemoteServerUtilTest.kt
+++ b/src/test/kotlin/io/titandata/remote/RemoteServerUtilTest.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
 package io.titandata.remote
 
 import io.kotlintest.shouldBe

--- a/src/test/kotlin/io/titandata/remote/archive/ArchiveRemoteTest.kt
+++ b/src/test/kotlin/io/titandata/remote/archive/ArchiveRemoteTest.kt
@@ -66,6 +66,9 @@ class ArchiveRemoteTest : StringSpec() {
 
         override fun endOperation(operation: RemoteOperation, isSuccessful: Boolean) {
         }
+
+        override fun pushMetadata(operation: RemoteOperation, commit: Map<String, Any>, isUpdate: Boolean) {
+        }
     }
 
     @InjectMockKs

--- a/src/test/kotlin/io/titandata/remote/archive/ArchiveRemoteTest.kt
+++ b/src/test/kotlin/io/titandata/remote/archive/ArchiveRemoteTest.kt
@@ -113,6 +113,7 @@ class ArchiveRemoteTest : StringSpec() {
                 parameters = emptyMap(),
                 operationId = "operation",
                 commitId = "commit",
+                commit = null,
                 type = type,
                 data = null)
     }

--- a/src/test/kotlin/io/titandata/remote/archive/ArchiveRemoteTest.kt
+++ b/src/test/kotlin/io/titandata/remote/archive/ArchiveRemoteTest.kt
@@ -1,0 +1,180 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
+package io.titandata.remote.archive
+
+import io.kotlintest.TestCase
+import io.kotlintest.TestResult
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.StringSpec
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.impl.annotations.OverrideMockKs
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.verify
+import io.titandata.remote.RemoteOperation
+import io.titandata.remote.RemoteOperationType
+import io.titandata.remote.RemoteProgress
+import io.titandata.shell.CommandExecutor
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+
+class ArchiveRemoteTest : StringSpec() {
+
+    @MockK
+    lateinit var executor: CommandExecutor
+
+    class TestRemote : ArchiveRemote() {
+        var archive: File? = null
+
+        override fun pushArchive(operation: RemoteOperation, volume: String, archive: File) {
+            this.archive = archive
+        }
+
+        override fun pullArchive(operation: RemoteOperation, volume: String, archive: File) {
+            this.archive = archive
+        }
+
+        override fun getProvider(): String {
+            return "test"
+        }
+
+        override fun validateRemote(remote: Map<String, Any>): Map<String, Any> {
+            return remote
+        }
+
+        override fun validateParameters(parameters: Map<String, Any>): Map<String, Any> {
+            return parameters
+        }
+
+        override fun listCommits(remote: Map<String, Any>, parameters: Map<String, Any>, tags: List<Pair<String, String?>>): List<Pair<String, Map<String, Any>>> {
+            return emptyList()
+        }
+
+        override fun getCommit(remote: Map<String, Any>, parameters: Map<String, Any>, commitId: String): Map<String, Any>? {
+            return null
+        }
+
+        override fun startOperation(operation: RemoteOperation) {
+        }
+
+        override fun endOperation(operation: RemoteOperation, isSuccessful: Boolean) {
+        }
+    }
+
+    @InjectMockKs
+    @OverrideMockKs
+    var server = TestRemote()
+
+    data class ProgressEntry(
+        val type: RemoteProgress,
+        val message: String?,
+        val percent: Int?
+    )
+
+    lateinit var progress: MutableList<ProgressEntry>
+
+    lateinit var scratchPath: Path
+
+    override fun beforeTest(testCase: TestCase) {
+        progress = mutableListOf()
+        scratchPath = Files.createTempDirectory("tst")
+        mockkConstructor(ProcessBuilder::class)
+        val builder: ProcessBuilder = mockk()
+        every { anyConstructed<ProcessBuilder>().directory(any()) } returns builder
+        every { builder.command(*anyVararg()) } returns builder
+        every { builder.start() } returns mockk()
+
+        return MockKAnnotations.init(this)
+    }
+
+    override fun afterTest(testCase: TestCase, result: TestResult) {
+        Files.delete(scratchPath)
+        clearAllMocks()
+    }
+
+    val updateProgress = fun(type: RemoteProgress, message: String?, percent: Int?) {
+        progress.add(ProgressEntry(type, message, percent))
+    }
+
+    fun getOperation(type: RemoteOperationType): RemoteOperation {
+        return RemoteOperation(
+                updateProgress = updateProgress,
+                remote = emptyMap(),
+                parameters = emptyMap(),
+                operationId = "operation",
+                commitId = "commit",
+                type = type,
+                data = null)
+    }
+
+    init {
+        "push updates progress correctly" {
+            every { executor.exec(any<Process>(), any()) } returns ""
+
+            server.syncVolume(getOperation(RemoteOperationType.PUSH), "volume", "description", "/path",
+                    scratchPath.toString())
+
+            progress.size shouldBe 4
+            progress[0].type shouldBe RemoteProgress.START
+            progress[0].message shouldBe "Creating archive for description"
+            progress[1].type shouldBe RemoteProgress.END
+            progress[1].message shouldBe null
+            progress[2].type shouldBe RemoteProgress.START
+            progress[2].message shouldBe "Pushing archive for description"
+            progress[3].type shouldBe RemoteProgress.END
+            progress[3].message shouldBe null
+        }
+
+        "push creates archive correctly" {
+            every { executor.exec(any<Process>(), any()) } returns ""
+
+            server.syncVolume(getOperation(RemoteOperationType.PUSH), "volume", "description", "/path",
+                    scratchPath.toString())
+
+            val archivePath = "$scratchPath/volume.tar.gz"
+            server.archive!!.path shouldBe archivePath
+
+            verify {
+                executor.exec(any<Process>(), "tar, czf, $archivePath, .")
+            }
+        }
+
+        "pull updates progress correctly" {
+            every { executor.exec(any<Process>(), any()) } returns ""
+
+            server.syncVolume(getOperation(RemoteOperationType.PULL), "volume", "description", "/path",
+                    scratchPath.toString())
+
+            progress.size shouldBe 4
+            progress[0].type shouldBe RemoteProgress.START
+            progress[0].message shouldBe "Pulling archive for description"
+            progress[1].type shouldBe RemoteProgress.END
+            progress[1].message shouldBe null
+            progress[2].type shouldBe RemoteProgress.START
+            progress[2].message shouldBe "Extracting archive for description"
+            progress[3].type shouldBe RemoteProgress.END
+            progress[3].message shouldBe null
+        }
+
+        "pull extracts archive correctly" {
+            every { executor.exec(any<Process>(), any()) } returns ""
+
+            server.syncVolume(getOperation(RemoteOperationType.PULL), "volume", "description", "/path",
+                    scratchPath.toString())
+
+            val archivePath = "$scratchPath/volume.tar.gz"
+            server.archive!!.path shouldBe archivePath
+
+            verify {
+                executor.exec(any<Process>(), "tar, xzf, $archivePath")
+            }
+        }
+    }
+}

--- a/src/test/kotlin/io/titandata/remote/rsync/RsyncExecutorTest.kt
+++ b/src/test/kotlin/io/titandata/remote/rsync/RsyncExecutorTest.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
 package io.titandata.remote.rsync
 
 import io.kotlintest.TestCase

--- a/src/test/kotlin/io/titandata/remote/rsync/RsyncRemoteTest.kt
+++ b/src/test/kotlin/io/titandata/remote/rsync/RsyncRemoteTest.kt
@@ -1,0 +1,163 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
+package io.titandata.remote.rsync
+
+import io.kotlintest.TestCase
+import io.kotlintest.TestResult
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.StringSpec
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.impl.annotations.OverrideMockKs
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.titandata.remote.RemoteOperation
+import io.titandata.remote.RemoteOperationType
+import io.titandata.remote.RemoteProgress
+import io.titandata.shell.CommandExecutor
+import java.nio.file.Files
+import java.nio.file.Path
+
+class RsyncRemoteTest : StringSpec() {
+
+    @MockK
+    lateinit var executor: CommandExecutor
+
+    class TestRemote : RsyncRemote() {
+        var src: String? = null
+        var dst: String? = null
+
+        override fun getRemotePath(operation: RemoteOperation, volume: String): String {
+            return "user@host:/path"
+        }
+
+        override fun getRsync(operation: RemoteOperation, src: String, dst: String, executor: CommandExecutor): RsyncExecutor {
+            this.src = src
+            this.dst = dst
+            return mockk(relaxed = true)
+        }
+
+        override fun getProvider(): String {
+            return "test"
+        }
+
+        override fun validateRemote(remote: Map<String, Any>): Map<String, Any> {
+            return remote
+        }
+
+        override fun validateParameters(parameters: Map<String, Any>): Map<String, Any> {
+            return parameters
+        }
+
+        override fun listCommits(remote: Map<String, Any>, parameters: Map<String, Any>, tags: List<Pair<String, String?>>): List<Pair<String, Map<String, Any>>> {
+            return emptyList()
+        }
+
+        override fun getCommit(remote: Map<String, Any>, parameters: Map<String, Any>, commitId: String): Map<String, Any>? {
+            return null
+        }
+
+        override fun startOperation(operation: RemoteOperation) {
+        }
+
+        override fun endOperation(operation: RemoteOperation, isSuccessful: Boolean) {
+        }
+    }
+
+    @InjectMockKs
+    @OverrideMockKs
+    var server = TestRemote()
+
+    data class ProgressEntry(
+        val type: RemoteProgress,
+        val message: String?,
+        val percent: Int?
+    )
+
+    lateinit var progress: MutableList<ProgressEntry>
+
+    lateinit var scratchPath: Path
+
+    override fun beforeTest(testCase: TestCase) {
+        progress = mutableListOf()
+        scratchPath = Files.createTempDirectory("tst")
+        mockkConstructor(ProcessBuilder::class)
+        val builder: ProcessBuilder = mockk()
+        every { anyConstructed<ProcessBuilder>().directory(any()) } returns builder
+        every { builder.command(*anyVararg()) } returns builder
+        every { builder.start() } returns mockk()
+
+        return MockKAnnotations.init(this)
+    }
+
+    override fun afterTest(testCase: TestCase, result: TestResult) {
+        Files.delete(scratchPath)
+        clearAllMocks()
+    }
+
+    val updateProgress = fun(type: RemoteProgress, message: String?, percent: Int?) {
+        progress.add(ProgressEntry(type, message, percent))
+    }
+
+    fun getOperation(type: RemoteOperationType): RemoteOperation {
+        return RemoteOperation(
+                updateProgress = updateProgress,
+                remote = emptyMap(),
+                parameters = emptyMap(),
+                operationId = "operation",
+                commitId = "commit",
+                type = type,
+                data = null)
+    }
+
+    init {
+        "push updates progress correctly" {
+            every { executor.exec(any<Process>(), any()) } returns ""
+
+            server.syncVolume(getOperation(RemoteOperationType.PUSH), "volume", "description", "/volume",
+                    scratchPath.toString())
+
+            progress.size shouldBe 1
+            progress[0].type shouldBe RemoteProgress.START
+            progress[0].message shouldBe "Syncing description"
+            progress[0].percent shouldBe 0
+        }
+
+        "push syncs data correctly" {
+            every { executor.exec(any<Process>(), any()) } returns ""
+
+            server.syncVolume(getOperation(RemoteOperationType.PUSH), "volume", "description", "/volume",
+                    scratchPath.toString())
+
+            server.src shouldBe "/volume"
+            server.dst shouldBe "user@host:/path"
+        }
+
+        "pull updates progress correctly" {
+            every { executor.exec(any<Process>(), any()) } returns ""
+
+            server.syncVolume(getOperation(RemoteOperationType.PULL), "volume", "description", "/volume",
+                    scratchPath.toString())
+
+            progress.size shouldBe 1
+            progress[0].type shouldBe RemoteProgress.START
+            progress[0].message shouldBe "Syncing description"
+            progress[0].percent shouldBe 0
+        }
+
+        "pull syncs data correctly" {
+            every { executor.exec(any<Process>(), any()) } returns ""
+
+            server.syncVolume(getOperation(RemoteOperationType.PULL), "volume", "description", "/volume",
+                    scratchPath.toString())
+
+            server.dst shouldBe "/volume"
+            server.src shouldBe "user@host:/path"
+        }
+    }
+}

--- a/src/test/kotlin/io/titandata/remote/rsync/RsyncRemoteTest.kt
+++ b/src/test/kotlin/io/titandata/remote/rsync/RsyncRemoteTest.kt
@@ -67,6 +67,9 @@ class RsyncRemoteTest : StringSpec() {
 
         override fun endOperation(operation: RemoteOperation, isSuccessful: Boolean) {
         }
+
+        override fun pushMetadata(operation: RemoteOperation, commit: Map<String, Any>, isUpdate: Boolean) {
+        }
     }
 
     @InjectMockKs

--- a/src/test/kotlin/io/titandata/remote/rsync/RsyncRemoteTest.kt
+++ b/src/test/kotlin/io/titandata/remote/rsync/RsyncRemoteTest.kt
@@ -114,6 +114,7 @@ class RsyncRemoteTest : StringSpec() {
                 parameters = emptyMap(),
                 operationId = "operation",
                 commitId = "commit",
+                commit = null,
                 type = type,
                 data = null)
     }


### PR DESCRIPTION
## Proposed Changes

This adds all the interfaces required to fully support remote operations. It also adds some base helper classes for Rsync and Archive remotes.

## Testing

Built and tested all new remotes against updated SDK. Built & ran all tests (including endtoend) in `titan-server`.