### PR TITLE
new remote API for data operations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,11 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
+
+apply(plugin="com.github.ben-manes.versions")
 
 buildscript {
     repositories {
@@ -13,7 +19,7 @@ buildscript {
 }
 
 plugins {
-    kotlin("jvm") version "1.3.50"
+    kotlin("jvm") version "1.3.60"
     id("com.github.ben-manes.versions") version("0.27.0")
     `maven-publish`
 }

--- a/src/main/kotlin/io/titandata/remote/RemoteServer.kt
+++ b/src/main/kotlin/io/titandata/remote/RemoteServer.kt
@@ -121,7 +121,7 @@ interface RemoteServer {
         scratchPath: String
     )
 
-    /**k
+    /**
      * Ends the data portion of an operation. This is called after all volumes have been synced, regardless of success
      * or failure. The 'operationData' parameter is passed from teh result of syncDataStart(). The 'isSuccessful' flag
      * indicates whether the operation was successful.
@@ -131,7 +131,7 @@ interface RemoteServer {
     /**
      * Push metadata for the commit to the remote. This can be done either when creating a new commit, or when
      * doing a metadata-only update (e.g. pushing new tags). The 'isUpdate' flag indicates whether we are updating
-     * existing metadata or creating new metadata. This method is not called for pull operations. Because this
+     * existing metadata or creating new metadata. This method is not called for pull operations.
      */
     fun pushMetadata(operation: RemoteOperation, commit: Map<String, Any>, isUpdate: Boolean)
 }

--- a/src/main/kotlin/io/titandata/remote/RemoteServer.kt
+++ b/src/main/kotlin/io/titandata/remote/RemoteServer.kt
@@ -45,8 +45,6 @@ enum class RemoteOperationType {
  *      commit              Commit metadata, if this is a push operation.
  *
  *      type                Operation type (push or pull)
- *
- *      userData            Optional data, set by startOperation(), that can be used during the course of the operation.
  */
 data class RemoteOperation(
     val updateProgress: (RemoteProgress, String?, Int?) -> Unit,
@@ -55,8 +53,7 @@ data class RemoteOperation(
     val operationId: String,
     val commitId: String,
     val commit: Map<String, Any>?,
-    val type: RemoteOperationType,
-    var data: Any?
+    val type: RemoteOperationType
 )
 
 /**
@@ -101,30 +98,40 @@ interface RemoteServer {
     fun getCommit(remote: Map<String, Any>, parameters: Map<String, Any>, commitId: String): Map<String, Any>?
 
     /**
-     * Starts a new operation. This method is invoked once for each operation, and is passed all context around
+     * Starts a new data operation. This method is invoked once for each operation, and is passed all context around
      * the operation, including remote configuration, commit ID, and unique identifier for the operation. This
-     * method may do nothing, but if needed it can do additional work and store operation-specific data in the
-     * 'data' member of the object.
+     * method may do nothing, but if needed it can do additional work and return operation-specific data that is
+     * later passed to each syncVolume() invocation. This method is only called when syncing data, metadata-only
+     * operations do not invoke this method (or any of the other
      */
-    fun startOperation(operation: RemoteOperation)
-
-    /**
-     * Ends an operation. This is called after all volumes have been synced, regardless of success or failure. The
-     * 'isSuccessful' flag indicates whether the operation was successful.
-     */
-    fun endOperation(operation: RemoteOperation, isSuccessful: Boolean)
+    fun syncDataStart(operation: RemoteOperation): Any?
 
     /**
      * Syncs a particular volume, push or pull. The operation type can be determined by the 'type' member of the
      * operation data. The volume data will be accessible at the 'volumePath' location. The 'scratchPath' is created
-     * once per operation, and can be used to store any temporary state, even across operations.
+     * once per operation, and can be used to store any temporary state, even across operations. The operationData
+     * parameter is passed from the result of syncDataStart().
      */
-    fun syncVolume(operation: RemoteOperation, volumeName: String, volumeDescription: String, volumePath: String, scratchPath: String)
+    fun syncDataVolume(
+        operation: RemoteOperation,
+        operationData: Any?,
+        volumeName: String,
+        volumeDescription: String,
+        volumePath: String,
+        scratchPath: String
+    )
+
+    /**k
+     * Ends the data portion of an operation. This is called after all volumes have been synced, regardless of success
+     * or failure. The 'operationData' parameter is passed from teh result of syncDataStart(). The 'isSuccessful' flag
+     * indicates whether the operation was successful.
+     */
+    fun syncDataEnd(operation: RemoteOperation, operationData: Any?, isSuccessful: Boolean)
 
     /**
      * Push metadata for the commit to the remote. This can be done either when creating a new commit, or when
      * doing a metadata-only update (e.g. pushing new tags). The 'isUpdate' flag indicates whether we are updating
-     * existing metadata or creating new metadata.
+     * existing metadata or creating new metadata. This method is not called for pull operations. Because this
      */
     fun pushMetadata(operation: RemoteOperation, commit: Map<String, Any>, isUpdate: Boolean)
 }

--- a/src/main/kotlin/io/titandata/remote/archive/ArchiveRemote.kt
+++ b/src/main/kotlin/io/titandata/remote/archive/ArchiveRemote.kt
@@ -19,11 +19,12 @@ abstract class ArchiveRemote : RemoteServer {
 
     internal val executor = CommandExecutor()
 
-    abstract fun pushArchive(operation: RemoteOperation, volume: String, archive: File)
-    abstract fun pullArchive(operation: RemoteOperation, volume: String, archive: File)
+    abstract fun pushArchive(operation: RemoteOperation, operationData: Any?, volume: String, archive: File)
+    abstract fun pullArchive(operation: RemoteOperation, operationData: Any?, volume: String, archive: File)
 
-    override fun syncVolume(
+    override fun syncDataVolume(
         operation: RemoteOperation,
+        operationData: Any?,
         volumeName: String,
         volumeDescription: String,
         volumePath: String,
@@ -41,13 +42,13 @@ abstract class ArchiveRemote : RemoteServer {
             operation.updateProgress(RemoteProgress.END, null, null)
 
             operation.updateProgress(RemoteProgress.START, "Pushing archive for $volumeDescription", null)
-            pushArchive(operation, volumeName, File(archive))
+            pushArchive(operation, operationData, volumeName, File(archive))
             File(archive).delete()
             operation.updateProgress(RemoteProgress.END, null, null)
         } else {
             operation.updateProgress(RemoteProgress.START, "Pulling archive for $volumeDescription", null)
             val archive = "$scratchPath/$volumeName.tar.gz"
-            pullArchive(operation, volumeName, File(archive))
+            pullArchive(operation, operationData, volumeName, File(archive))
             operation.updateProgress(RemoteProgress.END, null, null)
 
             operation.updateProgress(RemoteProgress.START,

--- a/src/main/kotlin/io/titandata/remote/rsync/RsyncRemote.kt
+++ b/src/main/kotlin/io/titandata/remote/rsync/RsyncRemote.kt
@@ -18,17 +18,18 @@ abstract class RsyncRemote : RemoteServer {
 
     internal val executor = CommandExecutor()
 
-    abstract fun getRemotePath(operation: RemoteOperation, volume: String): String
-    abstract fun getRsync(operation: RemoteOperation, src: String, dst: String, executor: CommandExecutor): RsyncExecutor
+    abstract fun getRemotePath(operation: RemoteOperation, operationData: Any?, volume: String): String
+    abstract fun getRsync(operation: RemoteOperation, operationData: Any?, src: String, dst: String, executor: CommandExecutor): RsyncExecutor
 
-    override fun syncVolume(
+    override fun syncDataVolume(
         operation: RemoteOperation,
+        operationData: Any?,
         volumeName: String,
         volumeDescription: String,
         volumePath: String,
         scratchPath: String
     ) {
-        val remotePath = getRemotePath(operation, volumeName)
+        val remotePath = getRemotePath(operation, operationData, volumeName)
         val (src, dst) = if (operation.type == RemoteOperationType.PUSH) {
             volumePath to remotePath
         } else {
@@ -36,7 +37,7 @@ abstract class RsyncRemote : RemoteServer {
         }
 
         operation.updateProgress(RemoteProgress.START, "Syncing $volumeDescription", 0)
-        val rsync = getRsync(operation, src, dst, executor)
+        val rsync = getRsync(operation, operationData, src, dst, executor)
         rsync.run()
     }
 }

--- a/src/test/kotlin/io/titandata/remote/archive/ArchiveRemoteTest.kt
+++ b/src/test/kotlin/io/titandata/remote/archive/ArchiveRemoteTest.kt
@@ -33,11 +33,11 @@ class ArchiveRemoteTest : StringSpec() {
     class TestRemote : ArchiveRemote() {
         var archive: File? = null
 
-        override fun pushArchive(operation: RemoteOperation, volume: String, archive: File) {
+        override fun pushArchive(operation: RemoteOperation, operationData: Any?, volume: String, archive: File) {
             this.archive = archive
         }
 
-        override fun pullArchive(operation: RemoteOperation, volume: String, archive: File) {
+        override fun pullArchive(operation: RemoteOperation, operationData: Any?, volume: String, archive: File) {
             this.archive = archive
         }
 
@@ -61,10 +61,10 @@ class ArchiveRemoteTest : StringSpec() {
             return null
         }
 
-        override fun startOperation(operation: RemoteOperation) {
+        override fun syncDataStart(operation: RemoteOperation) {
         }
 
-        override fun endOperation(operation: RemoteOperation, isSuccessful: Boolean) {
+        override fun syncDataEnd(operation: RemoteOperation, operationData: Any?, isSuccessful: Boolean) {
         }
 
         override fun pushMetadata(operation: RemoteOperation, commit: Map<String, Any>, isUpdate: Boolean) {
@@ -114,15 +114,14 @@ class ArchiveRemoteTest : StringSpec() {
                 operationId = "operation",
                 commitId = "commit",
                 commit = null,
-                type = type,
-                data = null)
+                type = type)
     }
 
     init {
         "push updates progress correctly" {
             every { executor.exec(any<Process>(), any()) } returns ""
 
-            server.syncVolume(getOperation(RemoteOperationType.PUSH), "volume", "description", "/path",
+            server.syncDataVolume(getOperation(RemoteOperationType.PUSH), null, "volume", "description", "/path",
                     scratchPath.toString())
 
             progress.size shouldBe 4
@@ -139,7 +138,7 @@ class ArchiveRemoteTest : StringSpec() {
         "push creates archive correctly" {
             every { executor.exec(any<Process>(), any()) } returns ""
 
-            server.syncVolume(getOperation(RemoteOperationType.PUSH), "volume", "description", "/path",
+            server.syncDataVolume(getOperation(RemoteOperationType.PUSH), null, "volume", "description", "/path",
                     scratchPath.toString())
 
             val archivePath = "$scratchPath/volume.tar.gz"
@@ -153,7 +152,7 @@ class ArchiveRemoteTest : StringSpec() {
         "pull updates progress correctly" {
             every { executor.exec(any<Process>(), any()) } returns ""
 
-            server.syncVolume(getOperation(RemoteOperationType.PULL), "volume", "description", "/path",
+            server.syncDataVolume(getOperation(RemoteOperationType.PULL), null, "volume", "description", "/path",
                     scratchPath.toString())
 
             progress.size shouldBe 4
@@ -170,7 +169,7 @@ class ArchiveRemoteTest : StringSpec() {
         "pull extracts archive correctly" {
             every { executor.exec(any<Process>(), any()) } returns ""
 
-            server.syncVolume(getOperation(RemoteOperationType.PULL), "volume", "description", "/path",
+            server.syncDataVolume(getOperation(RemoteOperationType.PULL), null, "volume", "description", "/path",
                     scratchPath.toString())
 
             val archivePath = "$scratchPath/volume.tar.gz"

--- a/src/test/kotlin/io/titandata/remote/rsync/RsyncRemoteTest.kt
+++ b/src/test/kotlin/io/titandata/remote/rsync/RsyncRemoteTest.kt
@@ -32,11 +32,11 @@ class RsyncRemoteTest : StringSpec() {
         var src: String? = null
         var dst: String? = null
 
-        override fun getRemotePath(operation: RemoteOperation, volume: String): String {
+        override fun getRemotePath(operation: RemoteOperation, operationData: Any?, volume: String): String {
             return "user@host:/path"
         }
 
-        override fun getRsync(operation: RemoteOperation, src: String, dst: String, executor: CommandExecutor): RsyncExecutor {
+        override fun getRsync(operation: RemoteOperation, operationData: Any?, src: String, dst: String, executor: CommandExecutor): RsyncExecutor {
             this.src = src
             this.dst = dst
             return mockk(relaxed = true)
@@ -62,10 +62,10 @@ class RsyncRemoteTest : StringSpec() {
             return null
         }
 
-        override fun startOperation(operation: RemoteOperation) {
+        override fun syncDataStart(operation: RemoteOperation) {
         }
 
-        override fun endOperation(operation: RemoteOperation, isSuccessful: Boolean) {
+        override fun syncDataEnd(operation: RemoteOperation, operationData: Any?, isSuccessful: Boolean) {
         }
 
         override fun pushMetadata(operation: RemoteOperation, commit: Map<String, Any>, isUpdate: Boolean) {
@@ -115,15 +115,14 @@ class RsyncRemoteTest : StringSpec() {
                 operationId = "operation",
                 commitId = "commit",
                 commit = null,
-                type = type,
-                data = null)
+                type = type)
     }
 
     init {
         "push updates progress correctly" {
             every { executor.exec(any<Process>(), any()) } returns ""
 
-            server.syncVolume(getOperation(RemoteOperationType.PUSH), "volume", "description", "/volume",
+            server.syncDataVolume(getOperation(RemoteOperationType.PUSH), null, "volume", "description", "/volume",
                     scratchPath.toString())
 
             progress.size shouldBe 1
@@ -135,7 +134,7 @@ class RsyncRemoteTest : StringSpec() {
         "push syncs data correctly" {
             every { executor.exec(any<Process>(), any()) } returns ""
 
-            server.syncVolume(getOperation(RemoteOperationType.PUSH), "volume", "description", "/volume",
+            server.syncDataVolume(getOperation(RemoteOperationType.PUSH), null, "volume", "description", "/volume",
                     scratchPath.toString())
 
             server.src shouldBe "/volume"
@@ -145,7 +144,7 @@ class RsyncRemoteTest : StringSpec() {
         "pull updates progress correctly" {
             every { executor.exec(any<Process>(), any()) } returns ""
 
-            server.syncVolume(getOperation(RemoteOperationType.PULL), "volume", "description", "/volume",
+            server.syncDataVolume(getOperation(RemoteOperationType.PULL), null, "volume", "description", "/volume",
                     scratchPath.toString())
 
             progress.size shouldBe 1
@@ -157,7 +156,7 @@ class RsyncRemoteTest : StringSpec() {
         "pull syncs data correctly" {
             every { executor.exec(any<Process>(), any()) } returns ""
 
-            server.syncVolume(getOperation(RemoteOperationType.PULL), "volume", "description", "/volume",
+            server.syncDataVolume(getOperation(RemoteOperationType.PULL), null, "volume", "description", "/volume",
                     scratchPath.toString())
 
             server.dst shouldBe "/volume"


### PR DESCRIPTION
## Proposed Changes

As part of refactoring for kubernetes support, we need the data sync operations to all run in a separate pod, while metadata operations can run within titan-server context. This change makes it more explicit that the start/sync/end methods are invoked during the data process, and moves the operation-specific data out of the RemoteOperation object so that you can't accidentally use it when pushing metadata. Previously, the endOperation was called after everything, which was problematic if part of it was going to run in titan-server and part in a separate pod. 

## Testing

`gradle build`, adapted to new WiP workflow in `titan-server`.